### PR TITLE
RST-1884: Add maintenance notice when Env Var is present

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -18,3 +18,9 @@
   background-position: 100% 50%;
   background-repeat: no-repeat;
 }
+
+.maintenance-notice p {
+  border: 5px solid #005ea5;
+  margin-top: 0.5em;
+  padding: 0.25em 0.5em;
+}

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -20,7 +20,8 @@
 }
 
 .maintenance-notice p {
-  border: 5px solid #005ea5;
+  border: 3px solid #005ea5;
   margin-top: 0.5em;
   padding: 0.25em 0.5em;
+  font-size: 0.85em;
 }

--- a/app/helpers/maintenance_notice_helper.rb
+++ b/app/helpers/maintenance_notice_helper.rb
@@ -1,0 +1,11 @@
+module MaintenanceNoticeHelper
+  def maintenance_notice
+    (start_time, end_time) = ENV['SHOW_DOWNTIME_BANNER'].split(',').
+      map { |d|  Time.zone.parse(d.strip).strftime("%l%P") }
+
+    day = Time.zone.parse(ENV['SHOW_DOWNTIME_BANNER'].split(',').last.strip).strftime("%e %B %Y")
+
+    "We're planning maintenance of this service. It will be unavailable from #{start_time} to #{end_time} on #{day}."
+  end
+
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,8 +38,7 @@
 - unless content_for?(:before_alerts)
   - content_for :before_alerts do
     = render partial: 'shared/feedback_link'
-    .column-full.maintenance-notice
-      p We're planning maintenance of this service. It will be unavailable from 9am to 2pm on 15 May 2019.
+    = render "shared/maintenance_notice" if ENV['SHOW_DOWNTIME_BANNER'].present?
 
 - content_for :content_override do
   main#content(role="main")

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,6 +38,8 @@
 - unless content_for?(:before_alerts)
   - content_for :before_alerts do
     = render partial: 'shared/feedback_link'
+    .column-full.maintenance-notice
+      p We're planning maintenance of this service. It will be unavailable from 9am to 2pm on 15 May 2019.
 
 - content_for :content_override do
   main#content(role="main")

--- a/app/views/shared/_maintenance_notice.slim
+++ b/app/views/shared/_maintenance_notice.slim
@@ -1,0 +1,2 @@
+.column-full.maintenance-notice
+  p = maintenance_notice


### PR DESCRIPTION

### Change description ###

When `SHOW_DOWNTIME_BANNER` environment variable is present, this PR ensures that a maintenance banner is shown on all service pages.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
