### PR TITLE
SSL Certificate Verification Control

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,4 +127,5 @@ end
 
 Raven.configure do |config|
   config.dsn = ENV['RAVEN_DSN'] || ""
+  config.ssl_verification = ENV.fetch('RAVEN_SSL_VERIFICATION', 'true').downcase == 'true'
 end


### PR DESCRIPTION
This PR allows configuration of the raven client to allow SSL certificate verification to be disabled by setting RAVEN_SSL_VERIFICATION=false as an environment variable (defaults to true)