### PR TITLE
Rst 1930 add country to primary claimant

### DIFF
--- a/app/views/api/claim/_build_primary_claimant.json.jbuilder
+++ b/app/views/api/claim/_build_primary_claimant.json.jbuilder
@@ -1,5 +1,5 @@
 json.uuid SecureRandom.uuid
 json.command 'BuildPrimaryClaimant'
 json.data do
-  json.partial! 'api/claim/claimant_attributes', claimant: claimant
+  json.partial! 'api/claim/primary_claimant_attributes', claimant: claimant
 end

--- a/app/views/api/claim/_primary_claimant_attributes.json.jbuilder
+++ b/app/views/api/claim/_primary_claimant_attributes.json.jbuilder
@@ -1,0 +1,24 @@
+# @TODO Send as simple value and transform at presentation layer ?
+json.title claimant.title.try(:titleize)
+json.first_name claimant.first_name
+json.last_name claimant.last_name
+claimant.address.tap do |a|
+  json.address_attributes do
+    json.building a.building
+    json.street a.street
+    json.locality a.locality
+    json.county a.county
+    json.post_code a.post_code
+    json.country({'united_kingdom' => "United Kingdom", "other" => "Outside United Kingdom"}[a.country])
+  end
+end
+json.address_telephone_number claimant.address_telephone_number
+json.mobile_number claimant.mobile_number
+json.fax_number claimant.fax_number
+json.email_address claimant.email_address
+# @TODO Maybe send as simple value and transform at presentation layer ?
+json.contact_preference claimant.contact_preference.try(:humanize)
+# @TODO Maybe send as simple value and transform at presentation layer ?
+json.gender({ 'male' => 'Male', 'female' => 'Female', 'prefer_not_to_say' => 'N/K' }[claimant.gender])
+json.date_of_birth claimant.date_of_birth
+json.special_needs claimant.special_needs

--- a/spec/support/api_support/json_objects/v2/build_primary_claimant_json_object.rb
+++ b/spec/support/api_support/json_objects/v2/build_primary_claimant_json_object.rb
@@ -9,7 +9,7 @@ module Et1
           def has_valid_json_for_model?(model, errors: [], indent: 1)
             expect(json).to include command: 'BuildPrimaryClaimant',
                                     uuid: instance_of(String)
-            expect(ClaimantJsonObject.new(json[:data])).to have_valid_json_for_model(model, errors: errors, indent: indent + 1)
+            expect(PrimaryClaimantJsonObject.new(json[:data])).to have_valid_json_for_model(model, errors: errors, indent: indent + 1)
           rescue RSpec::Expectations::ExpectationNotMetError => err
             errors << "Missing or invalid BuildPrimaryClaimant command json"
             errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })

--- a/spec/support/api_support/json_objects/v2/primary_claimant_json_object.rb
+++ b/spec/support/api_support/json_objects/v2/primary_claimant_json_object.rb
@@ -1,0 +1,38 @@
+require_relative './base'
+module Et1
+  module Test
+    module JsonObjects
+      module V2
+        # Represents the JSON attributes for a claimant
+        class PrimaryClaimantJsonObject < Base
+          include RSpec::Matchers
+
+          def has_valid_json_for_model?(example_claimant, errors: [], indent: 1)
+            example_address = example_claimant.address
+            expect(json).to include title: example_claimant.title.try(:titleize),
+                                         first_name: example_claimant.first_name,
+                                         last_name: example_claimant.last_name,
+                                         gender: { 'male' => 'Male', 'female' => 'Female', 'prefer_not_to_say' => 'N/K' }[example_claimant.gender],
+                                         email_address: example_claimant.email_address,
+                                         date_of_birth: example_claimant.date_of_birth.strftime('%Y-%m-%d'),
+                                         contact_preference: example_claimant.contact_preference.try(:humanize),
+                                         fax_number: example_claimant.fax_number,
+                                         special_needs: example_claimant.special_needs,
+                                         mobile_number: example_claimant.mobile_number,
+                                         address_telephone_number: example_claimant.address_telephone_number,
+                                         address_attributes: example_address.nil? || example_address.empty? ? {} : a_hash_including(building: example_address.building, county: example_address.county, locality: example_address.locality, post_code: example_address.post_code, street: example_address.street, country: mapped_country(example_address.country))
+          rescue RSpec::Expectations::ExpectationNotMetError => err
+            errors << "Missing or invalid claimant json"
+            errors.concat(err.message.lines.map { |l| "#{'  ' * indent}#{l.gsub(/\n\z/, '')}" })
+            false
+          end
+
+          def mapped_country(country)
+            return nil if country.nil?
+            {"united_kingdom" => "United Kingdom", "other" => "Outside United Kingdom"}[country]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/form_methods.rb
+++ b/spec/support/form_methods.rb
@@ -81,7 +81,7 @@ module FormMethods
     fill_in 'Month', with: '01'
     fill_in 'Year',  with: '1985'
 
-    fill_in_address
+    fill_in_address with_country: true
 
     fill_in 'Alternative phone',   with: '07956000000'
 
@@ -145,13 +145,14 @@ module FormMethods
     click_button 'Save and continue'
   end
 
-  def fill_in_address
+  def fill_in_address(with_country: false)
     fill_in 'Building number or name', with: '1'
     fill_in 'Street',                  with: 'High street'
     fill_in 'Town/city',               with: 'Anytown'
     fill_in 'County',                  with: 'Anyfordshire'
     fill_in 'Postcode',                with: 'AT1 4PQ'
     fill_in 'Phone',                   with: '01234567890'
+    select  'United Kingdom',          from: 'Country' if with_country
   end
 
   def fill_in_respondent_details


### PR DESCRIPTION
This PR adds the selected value of the claimant country to the API as it is required by CCD


### JIRA link (if applicable) ###
RST-1930


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

Whilst this does change the API, it adds to it and the API is programmed to ignore anything it doesnt care about.

A version of the API is in another branch ready to take advantage of this data, but this PR can be merged and deployed independently
