### PR TITLE
Confirmation page and emails now have new wording - also requires off…

### DIFF
--- a/app/jobs/fee_group_reference_job.rb
+++ b/app/jobs/fee_group_reference_job.rb
@@ -19,7 +19,8 @@ class FeeGroupReferenceJob < ActiveJob::Base
       code:      fee_group_reference.dig(:office, :code),
       name:      fee_group_reference.dig(:office, :name),
       address:   fee_group_reference.dig(:office, :address),
-      telephone: fee_group_reference.dig(:office, :telephone)
+      telephone: fee_group_reference.dig(:office, :telephone),
+      email:     fee_group_reference.dig(:office, :email)
     )
   end
 end

--- a/app/presenters/confirmation_presenter.rb
+++ b/app/presenters/confirmation_presenter.rb
@@ -1,11 +1,15 @@
 class ConfirmationPresenter < Presenter
   def submission_information
-    if office.present? && remission_claimant_count.zero?
-      submission_with_office_message
-    else
-      I18n.t 'claim_confirmations.show.submission_details.submission_without_office',
-        date: date(submitted_at)
+    I18n.t 'claim_confirmations.show.submission_details.submission',
+      date: date(submitted_at)
+  end
+
+  def office_information
+    return '' if office.nil?
+    if display_wales_address_in_welsh?
+      return I18n.t 'claim_confirmations.show.submission_details.office_address_wales', date: date(submitted_at)
     end
+    [office.name, office.email, office.telephone].join(', ')
   end
 
   def attachments
@@ -28,21 +32,13 @@ class ConfirmationPresenter < Presenter
   end
 
   def items
-    [:submission_information, :attachments]
+    [:submission_information, :office_information, :attachments]
   end
 
   def attachment_filenames
     @attachment_filenames ||= \
       [claim_details_rtf, additional_claimants_csv].
       map { |attachment| CarrierwaveFilename.for attachment }.compact
-  end
-
-  def submission_with_office_message
-    if display_wales_address_in_welsh?
-     return I18n.t 'claim_confirmations.show.submission_details.submission_with_office_wales', date: date(submitted_at)
-    end
-    I18n.t 'claim_confirmations.show.submission_details.submission_with_office',
-      date: date(submitted_at), office: [office.name, office.address].join(', ')
   end
 
   def display_wales_address_in_welsh?

--- a/config/locales/cy/claim_confirmation.cy.yml
+++ b/config/locales/cy/claim_confirmation.cy.yml
@@ -26,10 +26,10 @@ cy:
       submission_details:
         header: Manylion cyflwyno
         submission_information: Hawliad wedi'i gyflwyno
+        office_information: Swyddfa tribiwnlys
         attachments: Atodiadau wedi'u cynnwys
-        submission_without_office: "Cyflwynwyd ar %{date}"
-        submission_with_office: "Cyflwynwyd ar %{date} i swyddfa tribiwnlys %{office}"
-        submission_with_office_wales: "Cyflwynwyd ar %{date} i swyddfa tribiwnlys Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA"
+        submission: "Cyflwynwyd ar %{date}"
+        office_address_wales: "swyddfa tribiwnlys Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA"
 
       print_link_html: |
         <a href="javascript:window.print(0);">Argraffwch y dudalen hon</a> ar gyfer eich

--- a/config/locales/cy/mailers.cy.yml
+++ b/config/locales/cy/mailers.cy.yml
@@ -46,6 +46,7 @@ cy:
         see_attached_pdf: Gweler y PDF sydd ynghlwm
         attachments: 'Dogfennau ychwanegol:'
         submission_information: 'Hawliad wedi''i gyflwyno:'
+        office_information: 'Swyddfa tribiwnlys:'
         submitted_on: "ar %{date}"
         submitted_to: "i swyddfa tribiwnlys %{office}"
 

--- a/config/locales/en/claim_confirmation.en.yml
+++ b/config/locales/en/claim_confirmation.en.yml
@@ -11,11 +11,10 @@ en:
       what_happens_next:
         header: What happens next
         send_to_respondent: |
-          A copy of the claim will be sent to the respondent.
-          They’ll have 28 days to reply.
+          We'll contact you once we have sent your claim to the respondent and explain what happens next.
+          At present, this is taking us an of average of 25 days.
         next_steps: |
-          We’ll contact you when we’ve sent your claim to the respondent and
-          explain the next steps.
+          Once we have sent them your claim, the respondent has 28 days to reply.
         next_steps_final_step: |
           We’ll review your application for help with fees and let you know the outcome.
 
@@ -29,9 +28,9 @@ en:
       submission_details:
         header: Submission details
         submission_information: Claim submitted
+        office_information: Tribunal office
         attachments: Attachments included
-        submission_without_office: Submitted %{date}
-        submission_with_office: Submitted %{date} to tribunal office %{office}
+        submission: Submitted %{date}
 
       print_link_html: |
         <a href="javascript:window.print(0);">Print this page</a> for your

--- a/config/locales/en/mailers.en.yml
+++ b/config/locales/en/mailers.en.yml
@@ -42,6 +42,7 @@ en:
         see_attached_pdf: See attached PDF
         attachments: 'Additional documents:'
         submission_information: 'Claim submitted:'
+        office_information: 'Tribunal office:'
         submitted_on: "on %{date} "
         submitted_to: to tribunal office %{office}
 

--- a/db/migrate/20190719154415_add_email_to_offices.rb
+++ b/db/migrate/20190719154415_add_email_to_offices.rb
@@ -1,0 +1,5 @@
+class AddEmailToOffices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :offices, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_161051) do
+ActiveRecord::Schema.define(version: 2019_07_19_154415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_161051) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "claim_id"
+    t.string "email"
   end
 
   create_table "refunds", id: :serial, force: :cascade do |t|

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -9,7 +9,7 @@ WebMock.disable_net_connect!(allow_localhost: true, allow: [selenium_url.host, a
 Around('@mock_et_api') do |_scenario, block|
   ClimateControl.modify ET_API_URL: et_api_url do
     stub_request(:post, build_claim_url).with(headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }).to_return(body: '{}', status: 202, headers: { 'Content-Type': 'application/json' })
-    stub_request(:post, create_reference_url).with(headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }).to_return(body: { status: 'created', data: { reference: 'somereference' } }.to_json, status: 201, headers: { 'Content-Type': 'application/json' })
+    stub_request(:post, create_reference_url).with(headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }).to_return(body: { status: 'created', data: { reference: 'somereference', office: { code: 11, name: 'Puddletown', address: '1 Some road, Puddletown', telephone: '020 1234 5678', email: 'office@email.com' }} }.to_json, status: 201, headers: { 'Content-Type': 'application/json' })
     block.call
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -206,6 +206,7 @@ FactoryBot.define do
     name      { "Birmingham" }
     address   { "Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU" }
     telephone { "0121 600 7780" }
+    email     { "email@example.com" }
   end
 
   factory :employment do

--- a/spec/jobs/fee_group_reference_job_spec.rb
+++ b/spec/jobs/fee_group_reference_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe FeeGroupReferenceJob, type: :job do
   let(:claim) { create :claim }
   let(:postcode) { 'SW2 2WS' }
-  let(:fee_group_reference) { { reference: 1234567890, office: { code: 11, name: 'Puddletown', address: '1 Some road, Puddletown', telephone: '020 1234 5678' }} }
+  let(:fee_group_reference) { { reference: 1234567890, office: { code: 11, name: 'Puddletown', address: '1 Some road, Puddletown', telephone: '020 1234 5678', email: 'office@email.com' }} }
   let(:fee_group_reference_job) { FeeGroupReferenceJob.new }
 
   before do
@@ -19,7 +19,7 @@ describe FeeGroupReferenceJob, type: :job do
     end
 
     it 'saves office details' do
-      expect(claim).to receive(:create_office!).with(code: 11, name: 'Puddletown', address: '1 Some road, Puddletown', telephone: '020 1234 5678')
+      expect(claim).to receive(:create_office!).with(code: 11, name: 'Puddletown', address: '1 Some road, Puddletown', telephone: '020 1234 5678', email: 'office@email.com')
 
       fee_group_reference_job.perform(claim, postcode)
     end

--- a/spec/mailers/base_mailer_spec.rb
+++ b/spec/mailers/base_mailer_spec.rb
@@ -67,7 +67,7 @@ describe BaseMailer, type: :mailer do
 
       it 'has office' do
         expect(email).
-          to match_pattern 'Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
+          to match_pattern "Birmingham, email@example.com, 0121 600 7780"
       end
 
       it 'has an attachment' do
@@ -76,12 +76,12 @@ describe BaseMailer, type: :mailer do
 
       it "has what happen next step 1" do
         expect(email).
-          to match_pattern ['A copy of the claim will be sent to the respondent.', 'They’ll have 28 days to reply.']
+          to match_pattern ["contact you once we have sent your claim to the respondent and explain what happens next.",  "At present, this is taking us an of average of 25 days."]
       end
 
       it "has what happen next step 2" do
         expect(email).
-          to match_pattern ['We’ll contact you when we’ve sent your claim to the respondent', 'and explain the next steps.']
+          to match_pattern ['Once we have sent them your claim, the respondent has 28 days to reply.']
       end
 
       context 'when no office' do
@@ -127,7 +127,7 @@ describe BaseMailer, type: :mailer do
 
       it 'has office' do
         expect(email).
-          to match_pattern 'Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU'
+          to match_pattern "Birmingham, email@example.com, 0121 600 7780"
       end
 
       it 'has an attachment' do

--- a/spec/presenters/confirmation_presenter_spec.rb
+++ b/spec/presenters/confirmation_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ConfirmationPresenter, type: :presenter do
       context 'and no claimants seeking remission' do
         it 'has the submitted date, the name, and address of the fee centre' do
           expect(confirmation_presenter.submission_information).
-            to eq 'Submitted 01 January 2014 to tribunal office Brum, Brum lane, B1 1AA'
+            to eq 'Submitted 01 January 2014'
         end
 
         context 'Welsh locale' do
@@ -24,7 +24,7 @@ RSpec.describe ConfirmationPresenter, type: :presenter do
 
           it 'has the submitted date, the name, and address of the fee centre' do
             expect(confirmation_presenter.submission_information).
-              to eq 'Cyflwynwyd ar 01 Ionawr 2014 i swyddfa tribiwnlys Brum, Brum lane, B1 1AA'
+              to eq 'Cyflwynwyd ar 01 Ionawr 2014'
           end
 
           context 'Welsh address' do
@@ -34,7 +34,7 @@ RSpec.describe ConfirmationPresenter, type: :presenter do
 
             it 'has the submitted date, the name, and address of the fee centre' do
               expect(confirmation_presenter.submission_information).
-                to eq 'Cyflwynwyd ar 01 Ionawr 2014 i swyddfa tribiwnlys Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA'
+                to eq 'Cyflwynwyd ar 01 Ionawr 2014'
             end
           end
         end
@@ -67,7 +67,8 @@ RSpec.describe ConfirmationPresenter, type: :presenter do
   describe '#each_item' do
     it 'yields the submission information' do
       expect { |b| confirmation_presenter.each_item(&b) }.
-        to yield_successive_args [:submission_information, "Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU"],
+        to yield_successive_args [:submission_information, "Submitted 01 January 2014"],
+          [:office_information, "Birmingham, email@example.com, 0121 600 7780"],
           [:attachments, "file.rtf<br />file.csv"]
     end
 
@@ -76,7 +77,8 @@ RSpec.describe ConfirmationPresenter, type: :presenter do
 
       it 'yields text to state no attachments are present' do
         expect { |b| confirmation_presenter.each_item(&b) }.
-          to yield_successive_args [:submission_information, "Submitted 01 January 2014 to tribunal office Birmingham, Centre City Tower, 5­7 Hill Street, Birmingham B5 4UU"],
+          to yield_successive_args [:submission_information, "Submitted 01 January 2014"],
+            [:office_information, "Birmingham, email@example.com, 0121 600 7780"],
             [:attachments, "None"]
       end
     end


### PR DESCRIPTION

### JIRA link (if applicable) ###
RST-2008


### Change description ###

This PR introduces some wording changes to the confirmation page and associated email.

It requires (although wont break without) a change to the API to provide the office email address.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
