### PR TITLE
Revert "RST-1124 Changed the radio buttons for the email address to show once clicked"

### DIFF
--- a/app/forms/claimant_form.rb
+++ b/app/forms/claimant_form.rb
@@ -9,7 +9,6 @@ class ClaimantForm < Form
   include AddressAttributes.but_skip_postcode_validation
   include AgeValidator
 
-
   validates :address_post_code,
     post_code: true, length: { maximum: POSTCODE_LENGTH },
     unless: :international_address?
@@ -29,7 +28,6 @@ class ClaimantForm < Form
   boolean   :has_special_needs
 
   before_validation :reset_special_needs!, unless: :has_special_needs?
-  before_validation :clear_email_address, unless: :contact_preference_email?
 
   validates :first_name, :last_name, :address_country,
     :contact_preference, presence: true
@@ -79,9 +77,5 @@ class ClaimantForm < Form
 
   def reset_special_needs!
     self.special_needs = nil
-  end
-
-  def clear_email_address
-    self.email_address = nil
   end
 end

--- a/app/views/claims/_claimant.html.slim
+++ b/app/views/claims/_claimant.html.slim
@@ -32,20 +32,12 @@ fieldset
   = f.input :address_country, collection: ClaimantForm::COUNTRIES, include_blank: false
   = f.input :address_telephone_number, as: :tel, input_html: { class: 'medium-input' }
   = f.input :mobile_number, as: :tel, input_html: { class: 'medium-input' }
+  = f.input :email_address
 
-  = f.input :contact_preference,
-    collection: ClaimantForm::CONTACT_PREFERENCES,
-    as: :radio_buttons,
-    readonly: nil,
-    include_hidden: false,
-    item_wrapper_class: 'block-label',
-    wrapper_class: 'form-group-reveal reveal-publish-delegate',
-    input_html: { :class => 'reveal-publish-publisher'},
-    reveal: { "email" => 'email_address', "post" => 'email_address'}
-
-  = f.input :email_address,
-  wrapper_class: 'panel-indent toggle-content',
-  wrapper_html: { id: :email_address,
-                  :class => 'reveal-subscribe',
-                  :'data-target' => 'email_address',
-                  :'data-show-array' => 'email' }
+  fieldset
+    = f.input :contact_preference,
+      collection: ClaimantForm::CONTACT_PREFERENCES,
+      as: :radio_buttons,
+      readonly: nil,
+      include_hidden: false,
+      item_wrapper_class: 'block-label'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -47,18 +47,6 @@ SimpleForm.setup do |config|
     b.use :input
   end
 
-  # vertical input for radio buttons and check boxes
-  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
-    b.use :html5
-    b.optional :readonly
-    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
-      ba.use :label_text
-    end
-    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
-    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
-  end
-
   # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :default
 

--- a/features/output_form.feature
+++ b/features/output_form.feature
@@ -24,8 +24,8 @@ Feature: Output Form
       | country                      | United Kingdom              |
       | telephone_number             | 01234 567890                |
       | alternative_telephone_number | 01234 098765                |
-      | correspondence               | Email                       |
       | email_address                | test@digital.justice.gov.uk |
+      | correspondence               | Email                       |
     And I save the claimant details
     And I answer Yes to the group claims question
     And I fill in the first group claimant details with:

--- a/spec/forms/claimant_form_spec.rb
+++ b/spec/forms/claimant_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ClaimantForm, type: :form do
-  let(:claimant) { Claimant.new contact_preference: 'email' }
+  let(:claimant) { Claimant.new }
   let(:resource) { Claim.new primary_claimant: claimant }
 
   let(:claimant_form) { described_class.new Claim.new primary_claimant: claimant }
@@ -49,31 +49,18 @@ RSpec.describe ClaimantForm, type: :form do
       it { expect(claimant_form).to validate_length_of(number).is_at_most(21) }
     end
 
-    describe "presence of fax" do
-      describe "when contact_preference != fax" do
-        before { claimant_form.contact_preference = 'email'}
+    ['email_address', 'fax_number'].each do |attribute|
+      name = attribute.split('_').first
 
-        it { expect(claimant_form).not_to validate_presence_of(:fax_number) }
-      end
+      describe "presence of #{name}" do
+        describe "when contact_preference != #{name}" do
+          it { expect(claimant_form).not_to validate_presence_of(attribute) }
+        end
 
-      describe "when contact_preference == fax" do
-        before { claimant_form.contact_preference = 'fax'}
-
-        it { expect(claimant_form).to validate_presence_of(:fax_number) }
-      end
-    end
-
-    describe "presence of email" do
-      describe "when contact_preference != email" do
-        before { claimant_form.contact_preference = 'fax'}
-
-        it { expect(claimant_form).not_to validate_presence_of(:email_address) }
-      end
-
-      describe "when contact_preference == email" do
-        before { claimant_form.contact_preference = 'email'}
-
-        it { expect(claimant_form).to validate_presence_of(:email_address) }
+        describe "when contact_preference == #{name}" do
+          before { claimant_form.contact_preference = name }
+          it { expect(claimant_form).to validate_presence_of(attribute) }
+        end
       end
     end
   end
@@ -86,25 +73,6 @@ RSpec.describe ClaimantForm, type: :form do
 
       expect(claimant_form.special_needs).to be nil
     end
-
-    it 'clears the email address if contact preference is post' do
-      claimant_form.email_address = 'test@example.com'
-      claimant_form.contact_preference = 'post'
-
-      claimant_form.valid?
-
-      expect(claimant_form.email_address).to be_nil
-    end
-
-    it 'does not clear the email address if contact preference is email' do
-      claimant_form.email_address = 'test@example.com'
-      claimant_form.contact_preference = 'email'
-
-      claimant_form.valid?
-
-      expect(claimant_form.email_address).to eql 'test@example.com'
-    end
-
   end
 
   describe 'overridden attribute setters' do


### PR DESCRIPTION
Reverts hmcts/et1#1120

This PR reverts the above ticket - a last minute change has been requested to remove the optional text - plus it is breaking the test suite as the email address question has lost its 'form-group' class which is important