### PR TITLE
RST-2425 Solved problem with bitmask_attributes stopping rake db:create

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
   end
 
   scope :apply do
-    ActiveAdmin.routes(self)
+    ActiveAdmin.routes(self) unless $ARGV.include?('db:create')
     mount Sidekiq::Web => '/sidekiq'
   end
 


### PR DESCRIPTION


### JIRA link (if applicable) ###

RST-2425

### Change description ###

This PR (finally) fixes the issue where developers cannot create a database because there is no database - chicken and egg situation.

The workaround was to comment out 3 lines of code, create the db then uncomment them


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
