### PR TITLE
RST-2921 Remove Protective Award from 'About the claim' section

### DIFF
--- a/app/forms/claim_type_form.rb
+++ b/app/forms/claim_type_form.rb
@@ -2,7 +2,6 @@ class ClaimTypeForm < Form
   boolean :is_other_type_of_claim
 
   attribute :is_unfair_dismissal,                 :boolean
-  attribute :is_protective_award,                 :boolean
   attribute :discrimination_claims,               :array_of_strings_type
   attribute :pay_claims,                          :array_of_strings_type
   attribute :is_whistleblowing,                   :boolean

--- a/app/helpers/claim_reviews_helper.rb
+++ b/app/helpers/claim_reviews_helper.rb
@@ -46,10 +46,6 @@ module ClaimReviewsHelper
       claims << I18n.t("simple_form.labels.claim_type.is_unfair_dismissal")
     end
 
-    if claim.is_protective_award?
-      claims << I18n.t("simple_form.labels.claim_type.is_protective_award")
-    end
-
     claims.push(*claim.pay_claims.map { |c| I18n.t "simple_form.options.claim_type.pay_claims.#{c}" })
 
     claims.push(*claim.discrimination_claims.map { |c| I18n.t "simple_form.options.claim_type.discrimination_claims_for_review.#{c}" })

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -92,7 +92,7 @@ class Claim < ApplicationRecord
 
   # @TODO Rename this as it is only to determine the jurisdiction - maybe it should be in a helper as its presentational
   def attracts_higher_fee?
-    discrimination_claims.any? || is_unfair_dismissal? || is_whistleblowing? || is_protective_award?
+    discrimination_claims.any? || is_unfair_dismissal? || is_whistleblowing?
   end
 
   def finalize!

--- a/app/views/claims/_claim_type.html.slim
+++ b/app/views/claims/_claim_type.html.slim
@@ -15,18 +15,6 @@ fieldset
     required: true
 
 fieldset
-  legend.medium= t '.protective_award'
-  details
-    summary role="button" aria={controls: 'details-content-1', expanded: 'true'}
-      span.summary= t '.summary'
-    .panel-indent#details-content-1
-      p= t '.protective_award_summary_detail'
-  = f.input :is_protective_award,
-    as: :gds_check_boxes,
-    wrapper_class: 'options',
-    required: true
-
-fieldset
   legend.medium= t '.discrimination'
   = f.input :discrimination_claims, label: false,
     collection: Claim::DISCRIMINATION_COMPLAINTS,

--- a/config/locales/cy/claim_review.cy.yml
+++ b/config/locales/cy/claim_review.cy.yml
@@ -106,7 +106,6 @@ cy:
       claim_type:
         types: Math(au)
         is_whistleblowing: Chwythu'r chwiban
-        is_protective_award: "Dyfarniad Gwarchodol"
         send_claim_to_whistleblowing_entity: Anfon i gorff chwythu'r chwiban
 
       claim_details:

--- a/config/locales/cy/cy.yml
+++ b/config/locales/cy/cy.yml
@@ -323,7 +323,6 @@ cy:
 
       claim:
         is_unfair_dismissal: Diswyddo annheg (gan gynnwys diswyddo deongliadol)
-        is_protective_award: Dyfarniad Gwarchodol
         is_discrimination: Gwahaniaethu
         is_pay_related: Tâl
         is_other_type_of_claim: Math arall o hawliad
@@ -341,7 +340,6 @@ cy:
 
       claim_type:
         is_unfair_dismissal: Diswyddo annheg (gan gynnwys diswyddo deongliadol)
-        is_protective_award: "Dyfarniad Gwarchodol"
         is_other_type_of_claim: Math arall o hawliad
         other_claim_details: Nodwch y math arall o hawliad(au) ydych yn gwneud
         is_whistleblowing: "Ydych chi'n riportio'r posibilrwydd o gamymddwyn yn y gwaith?"
@@ -728,12 +726,9 @@ cy:
       claim_type: Ynglŷn â beth mae eich hawliad
       claim_type_label: "Dewiswch o leiaf un o'r mathau isod o hawliad."
       unfair_dismissal: Diswyddo annheg
-      protective_award: "Dyfarniad Gwarchodol"
       summary:  "Beth yw hyn?"
       unfair_dismissal_summary_detail: |
         Fe all eich diswyddiad fod yn annheg os nad oes gan eich cyflogwr reswm da dros eich diswyddo neu os nad yw wedi dilyn proses ddisgyblu ffurfiol neu broses ddiswyddo'r cwmni. Diswyddo deongliadol yw pan fyddwch yn cael eich gorfodi i adael eich swydd yn erbyn eich ewyllys oherwydd ymddygiad eich cyflogwr.
-      protective_award_summary_detail: |
-        Dyfarniad gwarchodol yw taliad a gaiff bob unigolyn a gafodd ei ddiswyddo mewn ymarfer dileu swydd pan fydd y cyflogwr wedi methu â hysbysu ac ymgynghori'n briodol ynghylch 20 neu fwy o ddiswyddiadau mewn cyfnod o 90 diwrnod
       discrimination: Gwahaniaethu
       pay: Tâl
       other_type: Math arall o hawliad (na ddangosir uchod)

--- a/config/locales/en/claim_review.en.yml
+++ b/config/locales/en/claim_review.en.yml
@@ -108,7 +108,6 @@ en:
       claim_type:
         types: Type(s)
         is_whistleblowing: Whistleblowing
-        is_protective_award: Protective Award
         send_claim_to_whistleblowing_entity: Send to whistleblowing body
 
       claim_details:

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -264,7 +264,6 @@ en:
 
       claim:
         is_unfair_dismissal: Unfair dismissal (including constructive dismissal)
-        is_protective_award: Protective Award
         is_discrimination: Discrimination
         is_pay_related: Pay
         is_other_type_of_claim: Another type of claim
@@ -282,7 +281,6 @@ en:
 
       claim_type:
         is_unfair_dismissal: Unfair dismissal (including constructive dismissal)
-        is_protective_award: Protective Award
         is_other_type_of_claim: Other type of claim
         other_claim_details: State the other type of claim(s) that you’re making
         is_whistleblowing: Are you reporting suspected wrongdoing at work?
@@ -668,12 +666,9 @@ en:
       claim_type: What your claim is about
       claim_type_label: Select at least one of the claim types below.
       unfair_dismissal: Unfair dismissal
-      protective_award: Protective award
       summary:  What is this?
       unfair_dismissal_summary_detail: |
         Your dismissal could be unfair if your employer doesn’t have a good reason for dismissing you or follow the company’s formal disciplinary or dismissal process. Constructive dismissal is when you’re forced to leave your job against your will because of your employer’s conduct.
-      protective_award_summary_detail: |
-        A protective award is an award of payment to each person dismissed in a redundancy exercise where the employer has failed to inform and consult appropriately about 20 or more dismissals in a 90 day period.
       discrimination: Discrimination
       pay: Pay
       other_type: Other type of claim (not shown above)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
     state { 'enqueued_for_submission' }
 
     is_unfair_dismissal { true }
-    is_protective_award { false }
 
     claim_details_rtf do
       Rack::Test::UploadedFile.new 'spec/support/files/file.rtf'

--- a/spec/features/claim_type_page_spec.rb
+++ b/spec/features/claim_type_page_spec.rb
@@ -19,9 +19,6 @@ feature 'Claim type page' do
       expect(page).not_to have_text("Unfair dismissal (including constructive dismissal) (optional)")
       expect(page).to have_text("Unfair dismissal (including constructive dismissal)")
 
-      expect(page).not_to have_text("Protective Award (optional)")
-      expect(page).to have_text("Protective Award")
-
       expect(page).not_to have_text("Other type of claim (optional)")
       expect(page).to have_text("Other type of claim")
 

--- a/spec/forms/claim_type_form_spec.rb
+++ b/spec/forms/claim_type_form_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe ClaimTypeForm, type: :form do
   it_behaves_like 'a Form',
     is_other_type_of_claim: true,
     is_unfair_dismissal: true,
-    is_protective_award: false,
     discrimination_claims: ['disability'],
     pay_claims: ['holiday'],
     is_whistleblowing: 'true',
@@ -58,7 +57,6 @@ RSpec.describe ClaimTypeForm, type: :form do
   describe "claim validation" do
     before do
       claim_type_form.is_unfair_dismissal = false
-      claim_type_form.is_protective_award = false
       claim_type_form.discrimination_claims = [""]
       claim_type_form.pay_claims = [""]
       claim_type_form.is_whistleblowing = false

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -156,11 +156,6 @@ RSpec.describe Claim, type: [:claim, :model] do
       it { expect(claim.attracts_higher_fee?).to be true }
     end
 
-    context 'when there is a protective award claim' do
-      before { claim_enqueued.is_protective_award = true }
-      it { expect(claim_enqueued.attracts_higher_fee?).to be true }
-    end
-
     context 'when claim is whistleblowing' do
       before { claim.is_whistleblowing = true }
       it { expect(claim.attracts_higher_fee?).to be true }
@@ -188,15 +183,6 @@ RSpec.describe Claim, type: [:claim, :model] do
       before do
         claim.is_unfair_dismissal = true
         claim.is_whistleblowing = true
-      end
-
-      it { expect(claim.attracts_higher_fee?).to be true }
-    end
-
-    context 'when there are claims of both unfair dismissal and protective award' do
-      before do
-        claim.is_unfair_dismissal = true
-        claim.is_protective_award = true
       end
 
       it { expect(claim.attracts_higher_fee?).to be true }

--- a/spec/views/claim_reviews/show/review_page_claim_type_spec.rb
+++ b/spec/views/claim_reviews/show/review_page_claim_type_spec.rb
@@ -25,7 +25,7 @@ describe "claim_reviews/show.html.slim" do
 
     let(:claim) do
       create :claim,
-        is_unfair_dismissal: true, is_protective_award: false,
+        is_unfair_dismissal: true,
         discrimination_claims: [:sex_including_equal_pay, :race, :sexual_orientation],
         pay_claims: [:redundancy, :other], other_claim_details: "yo\r\nyo",
         is_whistleblowing: true, send_claim_to_whistleblowing_entity: false


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2921

### Change description ###

This PR removes the protective award section from the claim type page.  This field does not go to the API so no further changes needed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
