### PR TITLE
RST-3076 Removed is_protective_award from claims table - no longer used

### DIFF
--- a/db/migrate/20210202120824_remove_is_protective_award_from_claims.rb
+++ b/db/migrate/20210202120824_remove_is_protective_award_from_claims.rb
@@ -1,0 +1,5 @@
+class RemoveIsProtectiveAwardFromClaims < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :claims, :is_protective_award, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_105200) do
+ActiveRecord::Schema.define(version: 2021_02_02_120824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,7 +88,6 @@ ActiveRecord::Schema.define(version: 2020_10_05_105200) do
     t.string "application_reference", null: false
     t.string "pdf"
     t.string "confirmation_email_recipients", default: [], array: true
-    t.boolean "is_protective_award", default: false
     t.string "pdf_url"
     t.index ["application_reference"], name: "index_claims_on_application_reference", unique: true
   end


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-3076


### Change description ###
RST-3076 Removed is_protective_award from claims table - no longer used


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
