### PR TITLE
RST-3223 Et date type now has option to allow 2 digit dates which is …

### DIFF
--- a/app/forms/additional_claimants_form/additional_claimant.rb
+++ b/app/forms/additional_claimants_form/additional_claimant.rb
@@ -10,7 +10,7 @@ class AdditionalClaimantsForm
 
     attribute :first_name,    :string
     attribute :last_name,     :string
-    attribute :date_of_birth, :et_date
+    attribute :date_of_birth, :et_date, allow_2_digit_year: true
     attribute :title,         :string
 
     booleans   :has_special_needs, :has_representative

--- a/app/types/et_date_type.rb
+++ b/app/types/et_date_type.rb
@@ -7,14 +7,22 @@
 #     the user gets an error on the form instead.
 class EtDateType < ActiveRecord::Type::Date
   # @param [Boolean] omit_day If true, allows a date without a day - will default to the first of the month
-  def initialize(omit_day: false)
+  def initialize(omit_day: false, allow_2_digit_year: false)
     @omit_day = omit_day
+    @allow_2_digit_year = allow_2_digit_year
     super()
   end
 
   private
 
-  attr_reader :omit_day
+  attr_reader :omit_day, :allow_2_digit_year
+
+  def new_date(year, mon, mday)
+    if allow_2_digit_year && year.present? && year < 100
+      year = 1900 + year
+    end
+    super(year, mon, mday)
+  end
 
   def value_from_multiparameter_assignment(value)
     defaults = {}


### PR DESCRIPTION

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###

RST-3223 Et date type now has option to allow 2 digit dates which is used in multiple claimant form


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
