### PR TITLE
RST-2039 Changed start link on diversity page to a button

### DIFF
--- a/app/views/diversities/index.html.slim
+++ b/app/views/diversities/index.html.slim
@@ -6,4 +6,5 @@
     p.govuk-body
       b = t '.anonymous'
 
-    = link_to (t '.begin_form'), new_diversity_path, class: "govuk-button govuk-button--start"
+    = form_for :new_diversity, url: new_diversity_path, method: :get, builder: EtGdsDesignSystem.form_builder_class do |f|
+      = f.submit t('.begin_form')


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
RST-2039


### Change description ###

The start link on the diversity page is now a button

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
