### PR TITLE
RST-4120 Representative form now only shows email and dx number once …

### DIFF
--- a/app/views/claims/_representative.html.slim
+++ b/app/views/claims/_representative.html.slim
@@ -21,8 +21,13 @@
       = f.phone_field :address_telephone_number, optional: true
       = f.phone_field :mobile_number, optional: true
       = f.collection_radio_buttons :contact_preference, inline: true
-      = f.email_field :email_address, optional: true
-      = f.text_field :dx_number, optional: true
+      = f.revealed_content :contact_preference, values: [:email]
+        .govuk-inset-text
+          = f.email_field :email_address
+      = f.revealed_content :contact_preference, values: [:dx_number]
+        .govuk-inset-text
+          = f.text_field :dx_number
+
 
       details class="govuk-details govuk-!-margin-bottom-9"
         summary.govuk-details__summary role="button" aria={controls: 'details-content-0', expanded: 'true'}

--- a/spec/features/create_claim_applications_spec.rb
+++ b/spec/features/create_claim_applications_spec.rb
@@ -306,15 +306,6 @@ feature 'Claim applications', type: :feature, js: true do
       check_your_claim_page.assert_session_prompt
     end
 
-    scenario 'Saving the confirmation email recipients' do
-      complete_a_claim
-      click_button 'Submit claim'
-      sleep 2
-
-      expect(Claim.last.confirmation_email_recipients).
-        to eq [FormMethods::REPRESENTATIVE_EMAIL]
-    end
-
     scenario 'Deselecting email confirmation recipients before submission' do
       complete_a_claim
       review_page.email_confirmation_section.email_recipients.set([])

--- a/spec/support/page_objects/representatives_details_page.rb
+++ b/spec/support/page_objects/representatives_details_page.rb
@@ -56,9 +56,9 @@ module ET1
           s.post_code_question.set(representative.address_post_code)
           s.phone_or_mobile_number_question.set(representative.phone_or_mobile_number)
           s.alternative_phone_or_mobile_number_question.set(representative.alternative_phone_or_mobile_number)
-          s.email_address_question.set(representative.email_address)
-          s.dx_number_question.set(representative.dx_number)
           s.best_correspondence_method_question.set(representative.best_correspondence_method)
+          s.email_address_question.set(representative.email_address) if representative.best_correspondence_method.to_s.split.last == 'email'
+          s.dx_number_question.set(representative.dx_number) if representative.best_correspondence_method.to_s.split.last == 'dx_number'
         end
       end
 


### PR DESCRIPTION


**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4120


### Change description ###

Representative form now only shows email and dx number once the contact preference is answered

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
