### PR TITLE
RST-4036 removed content for error on respondent detail's page

### DIFF
--- a/config/locales/en/et1/active_model.en.yml
+++ b/config/locales/en/et1/active_model.en.yml
@@ -202,7 +202,7 @@ en:
               blank: Enter the county from the respondent’s address
             address_post_code:
               blank: Enter the respondent’s postcode
-              invalid: Enter a valid UK postcode. If the respondent lives abroad, enter a SW55 9QT
+              invalid: Enter a valid UK postcode. If the respondent lives abroad, enter SW55 9QT
               invalid_ccd_post_code: :'activemodel.errors.models.respondent.attributes.address_post_code.invalid'
             worked_at_same_address:
               inclusion: Please indicate if you work at the same address

--- a/spec/forms/respondent_form_spec.rb
+++ b/spec/forms/respondent_form_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe RespondentForm, type: :form do
 
     include_examples "Postcode validation",
       attribute_prefix: 'address',
-      error_message: 'Enter a valid UK postcode. If the respondent lives abroad, enter a SW55 9QT'
+      error_message: 'Enter a valid UK postcode. If the respondent lives abroad, enter SW55 9QT'
 
     include_examples "Postcode validation",
       attribute_prefix: 'work_address',


### PR DESCRIPTION
Removed a letter for error message on Respondent detail's page 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
