### PR TITLE
RST-4275 Added before validation to clear field + Tests

### DIFF
--- a/app/forms/representative_form.rb
+++ b/app/forms/representative_form.rb
@@ -13,6 +13,7 @@ class RepresentativeForm < Form
   map_attribute :has_representative, to: :resource
 
   before_validation :destroy_target!, unless: :has_representative?
+  before_validation :clear_contact_preference_fields
 
   validates :type, :name, presence: true, if: :has_representative?
   validates :type, inclusion: { in: RepresentativeType::TYPES }, if: :has_representative?
@@ -40,5 +41,16 @@ class RepresentativeForm < Form
 
   def destroy_target!
     target.destroy
+  end
+
+  def clear_contact_preference_fields
+    if contact_preference == 'post'
+      self.dx_number = nil
+      self.email_address = nil
+    elsif contact_preference == 'email'
+      self.dx_number = nil
+    else
+      self.email_address = nil
+    end
   end
 end

--- a/spec/forms/representative_form_spec.rb
+++ b/spec/forms/representative_form_spec.rb
@@ -163,6 +163,44 @@ RSpec.describe RepresentativeForm, type: :form do
     end
   end
 
+  describe 'before validation' do
+    context 'when contact preference == post' do
+      before do
+        representative_form.email_address = 'emailgmailcom'
+        representative_form.dx_number = 'email@gmail.com'
+        representative_form.contact_preference = 'post'
+        representative_form.valid?
+      end
+      it 'email address and dx number should be nil' do
+        expect(representative_form).to have_attributes(email_address: nil, dx_number: nil)
+      end
+    end
+
+    context 'when contact preference == email' do
+      before do
+        representative_form.contact_preference = 'email'
+        representative_form.email_address = 'email@gmail.com'
+        representative_form.dx_number = 'email@gmail.com'
+        representative_form.valid?
+      end
+      it 'dx number should be nil' do
+        expect(representative_form.dx_number).to be_nil
+      end
+    end
+
+    context 'when contact preference == dx_number' do
+      before do
+        representative_form.contact_preference = 'dx_number'
+        representative_form.email_address = 'emailgmailcom'
+        representative_form.dx_number = 'R000000/00/00'
+        representative_form.valid?
+      end
+      it 'email address should be nil' do
+        expect(representative_form.email_address).to be_nil
+      end
+    end
+  end
+
   describe 'form' do
     subject { representative_form }
 


### PR DESCRIPTION
Added before validation to clear the fields of contact reference depending on what the user selected also added the test for each different case. 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
