### PR TITLE
RST-4511 - Additional hint text on Acas reveal

### DIFF
--- a/app/views/claims/_additional_respondents.html.slim
+++ b/app/views/claims/_additional_respondents.html.slim
@@ -20,7 +20,7 @@
           = builder.revealed_content :no_acas_number_reason, values: [:interim_relief], classes: ['form-hint'], tag: 'span'
             = t 'claims.respondent.no_acas_number_note_two'
         = builder.revealed_content :has_acas_number, values: [:true]
-          = builder.text_field :acas_early_conciliation_certificate_number
+          = builder.text_field :acas_early_conciliation_certificate_number, hint: { text: t('claims.respondent.acas_early_conciliation_certificate_number.hint', path:guide_path).html_safe }
         = builder.hidden_field :_destroy, data: { 'multiple-mark-for-destroy': true }
   - allow_more=f.object.secondary_respondents.length < Rails.application.config.additional_respondents_limit
   = f.submit t('.add_fields'),

--- a/config/locales/en/et1/claims/additional_respondents.en.yml
+++ b/config/locales/en/et1/claims/additional_respondents.en.yml
@@ -29,6 +29,7 @@ en:
         label: Postcode
       acas_early_conciliation_certificate_number:
         label: Acas early conciliation certificate number
+        hint: Nearly everyone should have this number before they fill in a claim form. You can find it on your Acas certificate. If you have been provided with an MU number from ACAS as part of a group notification you should use that number rather than an individual R prefixed certificate number.</br>Read more about the <a class="govuk-link" href="%{path}#acas_early_conciliation">Acas early conciliation service</a>.
       has_acas_number:
         label: Do you have an Acas number?
         options:

--- a/config/locales/en/et1/claims/respondent.en.yml
+++ b/config/locales/en/et1/claims/respondent.en.yml
@@ -47,7 +47,7 @@ en:
         label: Postcode
       acas_early_conciliation_certificate_number:
         label: Acas early conciliation certificate number
-        hint: Nearly everyone should have this number before they fill in a claim form. You can find it on your Acas certificate. Read more about the <a class="govuk-link" href="%{path}#acas_early_conciliation">Acas early conciliation service</a>.
+        hint: Nearly everyone should have this number before they fill in a claim form. You can find it on your Acas certificate. If you have been provided with an MU number from ACAS as part of a group notification you should use that number rather than an individual R prefixed certificate number.</br>Read more about the <a class="govuk-link" href="%{path}#acas_early_conciliation">Acas early conciliation service</a>.
       has_acas_number:
         label: Do you have an Acas number?
         options:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4511

### Change description ###

Content change (addition):
"If you have been provided with an MU number from ACAS as part of a group notification you should use that number rather than an individual R prefixed certificate number"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
