### PR TITLE
RST 4619 - Now making use of validation error 'options' containing things like count for I18m messages

### DIFF
--- a/app/services/validate_claimants_file_via_api_service.rb
+++ b/app/services/validate_claimants_file_via_api_service.rb
@@ -7,7 +7,7 @@ class ValidateClaimantsFileViaApiService < ApiService
 
   def call(record, attribute, value, uuid: SecureRandom.uuid)
     @record = record
-    @attribute = @attribute
+    @attribute = attribute
     json = ApplicationController.render 'api/claim/validate_claimants_file', format: :json, locals: {
       file: value, uuid: uuid
     }
@@ -19,7 +19,8 @@ class ValidateClaimantsFileViaApiService < ApiService
   def generate_custom_errors
     response_data['errors'].each do |error|
       source = error['source'] == '/' ? :base : error['source']
-      errors.add(source, error['code'])
+      options = (error['options'] || {}).deep_symbolize_keys
+      errors.add(source, error['code'], **options)
     end
   end
 end

--- a/app/validators/additional_claimants_csv_validator.rb
+++ b/app/validators/additional_claimants_csv_validator.rb
@@ -25,8 +25,8 @@ class AdditionalClaimantsCsvValidator < ActiveModel::EachValidator
       next if e.attribute == :base
 
       _, line_number, line_attribute = e.attribute.to_s.split('/').reject(&:blank?)
-      prefix =  I18n.t("activemodel.errors.models.#{record.class.model_name}.attributes.#{attribute}_row.row_prefix", line_number: line_number.to_i + 1)
-      error_text = I18n.t("activemodel.errors.models.#{record.class.model_name}.attributes.#{attribute}_row.attributes.#{line_attribute}.#{e.type}", line_number: line_number)
+      prefix =  I18n.t("activemodel.errors.models.#{record.class.model_name.i18n_key}.attributes.#{attribute}_row.row_prefix", line_number: line_number.to_i + 1)
+      error_text = I18n.t("activemodel.errors.models.#{record.class.model_name.i18n_key}.attributes.#{attribute}_row.attributes.#{line_attribute}.#{e.type}", line_number: line_number, **e.options)
       acc << "#{prefix} #{error_text}"
     end
     record.errors.add attribute,

--- a/spec/validators/additional_claimants_csv_validator_spec.rb
+++ b/spec/validators/additional_claimants_csv_validator_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe AdditionalClaimantsCsvValidator do
+  class ModelClass < ActiveRecord::Base
+    establish_connection adapter: :nulldb,
+                         schema: 'config/nulldb_schema.rb'
+
+    attribute :example_csv, :gds_azure_file
+    attribute :example_csv_record_count
+
+    validates :example_csv,
+              additional_claimants_csv: true
+  end
+  describe '#valid?' do
+    let(:example_base_api_url) { 'http://et-api.com' }
+    let(:example_translations) do
+      {
+        activemodel: {
+          errors: {
+            models: {
+              model_class: {
+                attributes: {
+                  example_csv_row: {
+                    row_prefix: 'Row %{line_number}',
+                    attributes: {
+                      title: { inclusion: 'The value "%{value}" is not in the list' },
+                      date_of_birth: { invalid: 'The date is invalid' },
+                      street: { too_long: 'The street value is greater than the maximum %{count}' },
+                      locality: { too_long: 'The locality value is greater than the maximum %{count}' },
+                      post_code: { invalid: 'The post code is invalid' }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+    around do |example|
+      I18n.backend.store_translations I18n.locale, example_translations
+      example.run
+      I18n.backend.reload!
+    end
+    it 'translates errors from API' do
+      response_body = {
+        "status": "not_accepted",
+        "uuid": "fbad7ec7-2da7-4e34-9509-d73c5e20ec72",
+        "errors": [
+          {
+            "status": 422,
+            "code": "invalid",
+            "title": "is invalid",
+            "detail": "is invalid",
+            "options": {},
+            "source": "/data_from_key/0/date_of_birth",
+            "command": "ValidateClaimantsFile",
+            "uuid": "fbad7ec7-2da7-4e34-9509-d73c5e20ec72"
+          },
+          {
+            "status": 422,
+            "code": "inclusion",
+            "title": "is not included in the list",
+            "detail": "is not included in the list",
+            "options": {
+              "value": "Dr"
+            },
+            "source": "/data_from_key/1/title",
+            "command": "ValidateClaimantsFile",
+            "uuid": "fbad7ec7-2da7-4e34-9509-d73c5e20ec72"
+          },
+          {
+            "status": 422,
+            "code": "too_long",
+            "title": "is too long (maximum is 50 characters)",
+            "detail": "is too long (maximum is 50 characters)",
+            "options": {
+              "count": 50
+            },
+            "source": "/data_from_key/2/street",
+            "command": "ValidateClaimantsFile",
+            "uuid": "fbad7ec7-2da7-4e34-9509-d73c5e20ec72"
+          },
+          {
+            "status": 422,
+            "code": "too_long",
+            "title": "is too long (maximum is 50 characters)",
+            "detail": "is too long (maximum is 50 characters)",
+            "options": {
+              "count": 50
+            },
+            "source": "/data_from_key/3/locality",
+            "command": "ValidateClaimantsFile",
+            "uuid": "fbad7ec7-2da7-4e34-9509-d73c5e20ec72"
+          },
+          {
+            "status": 422,
+            "code": "invalid",
+            "title": "is invalid",
+            "detail": "is invalid",
+            "options": {},
+            "source": "/data_from_key/5/post_code",
+            "command": "ValidateClaimantsFile",
+            "uuid": "fbad7ec7-2da7-4e34-9509-d73c5e20ec72"
+          }
+        ]
+      }
+      stub_request(:post, "#{example_base_api_url}/validate")
+               .with(body: hash_including(command: 'ValidateClaimantsFile'))
+               .to_return(status: 422, body: response_body.to_json, headers: { 'ContentType' => 'application/json' })
+      model = ModelClass.new(example_csv: { filename: 'a.txt', path: '/tmp/a.txt', content_type: 'text/csv' }.stringify_keys)
+
+      ClimateControl.modify ET_API_URL: example_base_api_url do
+        model.valid?
+      end
+      expect(model.errors.details[:example_csv]).to include error: :invalid,
+                                                            line_errors: containing_exactly(
+                                                              'Row 1 The date is invalid',
+                                                              'Row 2 The value "Dr" is not in the list',
+                                                              'Row 3 The street value is greater than the maximum 50',
+                                                              'Row 4 The locality value is greater than the maximum 50',
+                                                              'Row 6 The post code is invalid'
+                                                            )
+    end
+  end
+end


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###

Now making use of validation error 'options' containing things like count for I18m messages

This corrects an issue with the address error messages where the page crashed with an error as the interpolation value was not present

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
